### PR TITLE
Upgrade Pulumi.Kubernetes to 4.10.0

### DIFF
--- a/Pulumi.FSharp.Kubernetes/Myriad.fs
+++ b/Pulumi.FSharp.Kubernetes/Myriad.fs
@@ -1,3 +1,3 @@
 module private Kubernetes
 
-//module Force = let private nonce = 22515
+module Force = let private nonce = 2060885708

--- a/Pulumi.FSharp.Kubernetes/Pulumi.FSharp.Kubernetes.fsproj
+++ b/Pulumi.FSharp.Kubernetes/Pulumi.FSharp.Kubernetes.fsproj
@@ -1,58 +1,50 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <Description>F# computational expressions to reduce boilerplate in Pulumi code</Description>
-        <Copyright>Copyright 2020</Copyright>
-        <PackageProjectUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</PackageProjectUrl>
-        <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
-        <Title>$(MSBuildProjectName)</Title>
-        <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
-        <PackageTags>fsharp pulumi kubernetes</PackageTags>
-        <Company>Stefano d'Antonio (UnoSD)</Company>
-        <Authors>Stefano d'Antonio (UnoSD)</Authors>
-        <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <FSharpCoreImplicitPackageVersion>6.0.*</FSharpCoreImplicitPackageVersion>
-    </PropertyGroup>
-
-    <UsingTask TaskName="ForceRegenerate" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-        <Task>
-            <Using Namespace="System" />
-            <Using Namespace="System.IO" />
-            <Code Type="Fragment" Language="cs"><![CDATA[
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Description>F# computational expressions to reduce boilerplate in Pulumi code</Description>
+    <Copyright>Copyright 2020</Copyright>
+    <PackageProjectUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</PackageProjectUrl>
+    <PackageLicenseExpression>GPL-2.0-only</PackageLicenseExpression>
+    <Title>$(MSBuildProjectName)</Title>
+    <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
+    <PackageTags>fsharp pulumi kubernetes</PackageTags>
+    <Company>Stefano d'Antonio (UnoSD)</Company>
+    <Authors>Stefano d'Antonio (UnoSD)</Authors>
+    <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <FSharpCoreImplicitPackageVersion>6.0.*</FSharpCoreImplicitPackageVersion>
+  </PropertyGroup>
+  <UsingTask TaskName="ForceRegenerate" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
                 var number = new Random(DateTime.Now.Millisecond).Next();
                 File.WriteAllText("Myriad.fs", $"module private Kubernetes\n\nmodule Force = let private nonce = {number}");
                 Log.LogWarning("Force regenerate");
          ]]></Code>
-        </Task>
-    </UsingTask>
+    </Task>
+  </UsingTask>
+  <!-- To skip: -->
+  <!-- dotnet build Pulumi.FSharp.<provider> -p:NoRegenerate=true -->
+  <Target Name="CustomBeforeBuild" BeforeTargets="Build" Condition="'$(NoRegenerate)'!='true'">
+    <ForceRegenerate />
+  </Target>
+  <Import Project="../Pulumi.FSharp.Myriad\build\Pulumi.FSharp.Myriad.InTest.props" />
+ <ItemGroup>
+    <PackageReference Include="Myriad.Sdk" Version="0.8.1" PrivateAssets="All" />
+    <PackageReference Include="Pulumi.Kubernetes" Version="4.10.0" />
+    <PackageReference Include="Pulumi.FSharp" Version="3.43.1" />
+    <PackageReference Include="FSharp.Core" />
 
-    <!-- To skip: -->
-    <!-- dotnet build Pulumi.FSharp.<provider> -p:NoRegenerate=true -->
-    <Target Name="CustomBeforeBuild" BeforeTargets="Build" Condition="'$(NoRegenerate)'!='true'">
-        <ForceRegenerate />
-    </Target>
-
-    <Import Project="../Pulumi.FSharp.Myriad\build\Pulumi.FSharp.Myriad.InTest.props" />
-
-    <ItemGroup>
-        <PackageReference Include="Pulumi.Kubernetes" Version="4.5.2" />
-        <PackageReference Include="Pulumi.FSharp" Version="3.43.1" />
-        <PackageReference Include="FSharp.Core" />
-        <PackageReference Include="Myriad.Sdk" Version="0.8.1" PrivateAssets="All" />
-        <!-- This is required only to force build of the plugin -->
-        <ProjectReference Include="../Pulumi.FSharp.Myriad\Pulumi.FSharp.Myriad.fsproj" PrivateAssets="All" />
-
-        <Compile Include="Myriad.fs" />
-
-        <Compile Include="Generated.fs">
-            <MyriadFile>Myriad.fs</MyriadFile>
-        </Compile>
-
-        <None Include="myriad.toml" />
-
-        <PackageReference Update="FSharp.Core" Version="6.0.6" />
-    </ItemGroup>
-
+    <!-- This is required only to force build of the plugin -->
+    <ProjectReference Include="../Pulumi.FSharp.Myriad\Pulumi.FSharp.Myriad.fsproj" PrivateAssets="All" />
+ </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Generated.fs">
+      <MyriadFile>Myriad.fs</MyriadFile>
+    </Compile>
+    <Compile Include="Myriad.fs" />
+    <None Include="myriad.toml" />
+  </ItemGroup>
 </Project>

--- a/Pulumi.FSharp.Myriad/Modules.fs
+++ b/Pulumi.FSharp.Myriad/Modules.fs
@@ -238,6 +238,7 @@ let private missingStatusTypes =
         "ResourceClaim"
         "PodScheduling"
         "ValidatingAdmissionPolicy"
+        "ServiceCIDR"
     |] |> Set.ofArray
 
 let createTypes (schema : JsonValue) =

--- a/Pulumi.FSharp.Myriad/Operations.fs
+++ b/Pulumi.FSharp.Myriad/Operations.fs
@@ -299,18 +299,15 @@ let croOperation operationName description argumentName (setAssignmentExpression
         PreXmlDoc.Create([ description ]) |> Some
     
     let updateCrosExpression setAssignmentExpression =
-        let setExpression =
-            Expr.set($"cros.{operationName}", setAssignmentExpression)
-        
         let lambdaExpression =
             Expr.sequential([
-                setExpression
+                Expr.set($"cros.{operationName}", setAssignmentExpression)
                 Expr.ident("cros")
             ])
         
         let listConsLambdaFirstExpression =
             Expr.lambda([
-                SimplePat.typed("cros", "CustomResourceOptions")
+                SimplePat.typed("cros", "ResourceOptions")
             ], lambdaExpression)
         
         let listConsExpressions =

--- a/Pulumi.FSharp.Myriad/Pulumi.FSharp.Myriad.fsproj
+++ b/Pulumi.FSharp.Myriad/Pulumi.FSharp.Myriad.fsproj
@@ -1,14 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <LangVersion>preview</LangVersion>
         <NoWarn>NU1605,NU1608</NoWarn>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <RootNamespace>Pulumi.FSharp.Myriad</RootNamespace>
-        <FSharpCoreImplicitPackageVersion>6.0.*</FSharpCoreImplicitPackageVersion>
     </PropertyGroup>
-
     <ItemGroup>
         <Content Include="build\Pulumi.FSharp.Myriad.props">
             <Pack>true</Pack>
@@ -17,7 +14,6 @@
         </Content>
         <Content Include="build\Pulumi.FSharp.Myriad.InTest.props" />
     </ItemGroup>
-    
     <ItemGroup>
         <Compile Include="Core.fs" />
         <Compile Include="AstHelpers.fs" />
@@ -37,15 +33,11 @@
         <Compile Include="IndexModule.fs" />
         <Compile Include="Generator.fs" />
     </ItemGroup>
-    
     <ItemGroup>
         <PackageReference Include="FSharp.Core" />
         <PackageReference Include="FSharp.Data" Version="5.0.2" />
         <PackageReference Include="FSharp.Text.RegexProvider" Version="2.1.0" />
         <PackageReference Include="Myriad.Core" Version="0.8.1" />
         <PackageReference Include="Myriad.Sdk" Version="0.8.1" />
-        
-        <PackageReference Update="FSharp.Core" Version="6.0.6" />
-    </ItemGroup>
-    
+    </ItemGroup> 
 </Project>


### PR DESCRIPTION
This PR adds `ServiceCIDR` to `missingStatusTypes` and adds logic to generate `ComponentResourceOptions` instead of `CustomResourceOptions` on `ConfigFile` and `ConfigGroup`. Minor cleanup of fsproj files and generator code.