### PR TITLE
fix(k8s): ast helper generates hash constraint for ResourceOptions

### DIFF
--- a/Pulumi.FSharp.Myriad/AstHelpers.fs
+++ b/Pulumi.FSharp.Myriad/AstHelpers.fs
@@ -11,11 +11,19 @@ type SimplePat =
     /// str
     static member id(str) =
         SynSimplePat.Id(Ident.Create(str), None, false, false, false, range.Zero)
-        
+
+    static member hashTyped (str, type': string) =
+        SynSimplePat.CreateTyped(
+            Ident.Create str,
+            SynType.HashConstraint(
+                SynType.CreateLongIdent(type'),
+                range.Zero))
+
     static member typed(str, type' : string) =
-        SynSimplePat.Typed(SimplePat.id(str),
-                           SynType.CreateLongIdent(type'),
-                           range.Zero)
+        SynSimplePat.Typed(
+            SimplePat.id(str),
+            SynType.CreateLongIdent(type'),
+            range.Zero)
 
 type SynPat with
     static member CreateTuple(args : SynPat list) =

--- a/Pulumi.FSharp.Myriad/Operations.fs
+++ b/Pulumi.FSharp.Myriad/Operations.fs
@@ -307,7 +307,7 @@ let croOperation operationName description argumentName (setAssignmentExpression
         
         let listConsLambdaFirstExpression =
             Expr.lambda([
-                SimplePat.typed("cros", "ResourceOptions")
+                SimplePat.hashTyped("cros", "ResourceOptions")
             ], lambdaExpression)
         
         let listConsExpressions =


### PR DESCRIPTION
We need to generate `#ResourceOptions` so that `ConfigFile` and `ConfigGroup`'s `ComponentResourceOptions` type check properly.