### PR TITLE
fix(build): fix build order for providers using Pulumi.FSharp.Myriad

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: .NET Publish
+name: .NET Build and Test
 
 on:
   pull_request:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,12 +18,6 @@ jobs:
           global-json-file: global.json
           dotnet-version: |
             8.x
-      - name: Build Pulumi.FSharp.Extensions
-        env:
-          FAKE_DETAILED_ERRORS: true
-          ENABLE_COVERAGE: false # AltCover doesn't work with Release builds, reports lower coverage than actual
-        run: |
-          ./build.sh DotnetBuild
       - name: Build providers
         env:
           FAKE_DETAILED_ERRORS: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,13 +6,15 @@ See https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-director
 
 <Project>
     <PropertyGroup>
-        <PackageTags>f#, fsharp</PackageTags>
+        <Description>F# computational expressions to reduce boilerplate in Pulumi code</Description>
+        <Copyright>Copyright 2021</Copyright>
+        <Authors>Stefano d'Antonio (UnoSD), Cadence Agyirey (cagyirey)</Authors>
+        <PackageTags>f#, fsharp, pulumi, iac</PackageTags>
         <PackageProjectUrl>https://github.com/cagyirey/Pulumi.FSharp.Extensions</PackageProjectUrl>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile> <!--https://docs.microsoft.com/en-gb/nuget/reference/msbuild-targets#packagereadmefile -->
         <RepositoryType>git</RepositoryType>
-        <Authors>UnoSD, Cadence Agyirey</Authors>
         <RepositoryUrl>https://github.com/cagyirey/Pulumi.FSharp.Extensions</RepositoryUrl>
     </PropertyGroup>
     <PropertyGroup>

--- a/build/build.fs
+++ b/build/build.fs
@@ -845,7 +845,8 @@ let initTargets () =
         Target.create $"BuildProvider.{providerName}" (buildProvider projectFile)
         Target.create $"PackProvider.{providerName}" (packProvider projectFile)
 
-        $"BuildProvider.{providerName}"
+        "DotnetBuild"
+        ==> $"BuildProvider.{providerName}"
         ==>! $"PackProvider.{providerName}"
 
         "DotnetRestore"
@@ -910,13 +911,6 @@ let initTargets () =
     ==> "GenerateAssemblyInfo"
     ==> "GitRelease"
     ==>! "Release"
-
-    "DotnetRestore"
-    ==> "BuildProviders"
-    ==> "PackProviders"
-    ==> "PublishToNuGet"
-    // ==> "GitHubRelease"
-    ==>! "Publish"
 
     "DotnetRestore"
     =?> ("CheckFormatCode", isCI.Value)

--- a/build/build.fs
+++ b/build/build.fs
@@ -845,6 +845,9 @@ let initTargets () =
         Target.create $"BuildProvider.{providerName}" (buildProvider projectFile)
         Target.create $"PackProvider.{providerName}" (packProvider projectFile)
 
+        "Clean"
+        ==>! $"PackProvider.{providerName}"
+
         "DotnetBuild"
         ==> $"BuildProvider.{providerName}"
         ==>! $"PackProvider.{providerName}"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -16,7 +16,7 @@ group Main
   storage: none
 
   nuget FSharp.Core ~> 8
-  nuget Myriad.Sdk 0.8.1
+  nuget Myriad.Sdk 0.8.1 copy_local: true
 
   nuget Pulumi.Aws
   nuget Pulumi.Auth0

--- a/paket.lock
+++ b/paket.lock
@@ -54,7 +54,7 @@ NUGET
       Microsoft.TestPlatform.ObjectModel (>= 17.10)
       Newtonsoft.Json (>= 13.0.1)
     Mono.Cecil (0.11.5)
-    Myriad.Sdk (0.8.1)
+    Myriad.Sdk (0.8.1) - copy_local: true
     Newtonsoft.Json (13.0.3)
     OneOf (3.0.271)
     Pulumi (3.63.1)
@@ -71,8 +71,6 @@ NUGET
     Pulumi.Auth0 (3.3.1)
       Pulumi (>= 3.60)
     Pulumi.Aws (6.33.1)
-      Pulumi (>= 3.63.1)
-    Pulumi.Aws (6.38)
       Pulumi (>= 3.63.1)
     Pulumi.Azure (5.79)
       Pulumi (>= 3.63.1)

--- a/providers/Pulumi.FSharp.Auth0/Pulumi.FSharp.Auth0.fsproj
+++ b/providers/Pulumi.FSharp.Auth0/Pulumi.FSharp.Auth0.fsproj
@@ -2,16 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Description>F# computational expressions to reduce boilerplate in Pulumi code</Description>
-    <Copyright>Copyright 2021</Copyright>
-    <PackageProjectUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</PackageProjectUrl>
     <Title>$(MSBuildProjectName)</Title>
-    <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
-    <PackageTags>fsharp pulumi auth0 identity oidc oauth</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageTags>fsharp pulumi auth0 identity oidc oauth</PackageTags>
   </PropertyGroup>
   <UsingTask TaskName="ForceRegenerate" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <Task>

--- a/providers/Pulumi.FSharp.Aws/Pulumi.FSharp.Aws.fsproj
+++ b/providers/Pulumi.FSharp.Aws/Pulumi.FSharp.Aws.fsproj
@@ -2,14 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Description>F# computational expressions to reduce boilerplate in Pulumi code</Description>
-    <Copyright>Copyright 2020</Copyright>
-    <PackageProjectUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</PackageProjectUrl>
-    <Title>$(MSBuildProjectName)</Title>
-    <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi aws</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.Azure/Pulumi.FSharp.Azure.fsproj
+++ b/providers/Pulumi.FSharp.Azure/Pulumi.FSharp.Azure.fsproj
@@ -2,14 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Description>F# computational expressions to reduce boilerplate in Pulumi code</Description>
-    <Copyright>Copyright 2020</Copyright>
-    <PackageProjectUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</PackageProjectUrl>
-    <Title>$(MSBuildProjectName)</Title>
-    <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi azure</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.AzureAD/Pulumi.FSharp.AzureAD.fsproj
+++ b/providers/Pulumi.FSharp.AzureAD/Pulumi.FSharp.AzureAD.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi azuread</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.AzureNative/Pulumi.FSharp.AzureNative.fsproj
+++ b/providers/Pulumi.FSharp.AzureNative/Pulumi.FSharp.AzureNative.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi azure</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.AzureNativeV2/Pulumi.FSharp.AzureNativeV2.fsproj
+++ b/providers/Pulumi.FSharp.AzureNativeV2/Pulumi.FSharp.AzureNativeV2.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi azure</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.Command/Pulumi.FSharp.Command.fsproj
+++ b/providers/Pulumi.FSharp.Command/Pulumi.FSharp.Command.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi command</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.DigitalOcean/Pulumi.FSharp.DigitalOcean.fsproj
+++ b/providers/Pulumi.FSharp.DigitalOcean/Pulumi.FSharp.DigitalOcean.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi digitalocean</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.Docker/Pulumi.FSharp.Docker.fsproj
+++ b/providers/Pulumi.FSharp.Docker/Pulumi.FSharp.Docker.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi docker</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.Gcp/Pulumi.FSharp.Gcp.fsproj
+++ b/providers/Pulumi.FSharp.Gcp/Pulumi.FSharp.Gcp.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi gcp</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.Kubernetes/Pulumi.FSharp.Kubernetes.fsproj
+++ b/providers/Pulumi.FSharp.Kubernetes/Pulumi.FSharp.Kubernetes.fsproj
@@ -2,17 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Description>F# computational expressions to reduce boilerplate in Pulumi code</Description>
-    <Copyright>Copyright 2020</Copyright>
-    <PackageProjectUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</PackageProjectUrl>
-    <Title>$(MSBuildProjectName)</Title>
-    <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi kubernetes</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <FSharpCoreImplicitPackageVersion>6.0.*</FSharpCoreImplicitPackageVersion>
   </PropertyGroup>
   <UsingTask TaskName="ForceRegenerate" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <Task>

--- a/providers/Pulumi.FSharp.Random/Pulumi.FSharp.Random.fsproj
+++ b/providers/Pulumi.FSharp.Random/Pulumi.FSharp.Random.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi random</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/providers/Pulumi.FSharp.Tls/Pulumi.FSharp.Tls.fsproj
+++ b/providers/Pulumi.FSharp.Tls/Pulumi.FSharp.Tls.fsproj
@@ -8,8 +8,6 @@
     <Title>$(MSBuildProjectName)</Title>
     <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi tls</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <NoWarn>NU1605,NU1608,FS0058,FS0044</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Pulumi.FSharp.Core/Pulumi.FSharp.Core.fsproj
+++ b/src/Pulumi.FSharp.Core/Pulumi.FSharp.Core.fsproj
@@ -2,14 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Description>F# computational expressions to reduce boilerplate in Pulumi code</Description>
-    <Copyright>Copyright 2020</Copyright>
-    <PackageProjectUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</PackageProjectUrl>
-    <Title>$(MSBuildProjectName)</Title>
-    <RepositoryUrl>https://github.com/UnoSD/Pulumi.FSharp.Extensions</RepositoryUrl>
     <PackageTags>fsharp pulumi azure</PackageTags>
-    <Company>Stefano d'Antonio (UnoSD)</Company>
-    <Authors>Stefano d'Antonio (UnoSD)</Authors>
     <PackageVersion>3.1.4</PackageVersion>
     <NoWarn>NU1605,NU1608</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This PR ensures that we run `DotnetBuild` prior to any provider builds. Previously, we forced a build of the Myriad plugin using `ProjectReference` in Pulumi provider projects. We use FAKE for this now, so we can remove the package reference from provider packages entirely. This PR also updates the package metadata to reflect the new home of the project. 