### PR TITLE
Automatically run Paket Update in CI

### DIFF
--- a/.github/workflows/paket-autoupdate.yml
+++ b/.github/workflows/paket-autoupdate.yml
@@ -1,0 +1,25 @@
+name: Paket Update
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"
+      
+jobs:
+  paket-update:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup necessary dotnet SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+          dotnet-version: |
+            8.x
+      - name: Paket Update
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FAKE_DETAILED_ERRORS: true
+        run: |
+          ./build.sh PaketUpdate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,11 @@ jobs:
           global-json-file: global.json
           dotnet-version: |
             8.x
-      - name: publish
+      - name: Publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUGET_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this is intentional — we publish to github packages
           FAKE_DETAILED_ERRORS: true
           ENABLE_COVERAGE: false # AltCover doesn't work with Release builds, reports lower coverage than actual
         run: |
-          chmod +x ./build.sh
           ./build.sh Publish

--- a/build/build.fs
+++ b/build/build.fs
@@ -868,7 +868,7 @@ let initTargets () =
     Target.create "GenerateAssemblyInfo" generateAssemblyInfo
     Target.create "DotnetPack" dotnetPack
     Target.create "PackProviders" ignore
-    Target.create "PushProviders" ignore
+    Target.create "PublishProviders" ignore
     Target.create "SourceLinkTest" sourceLinkTest
     Target.create "PublishToNuGet" publishToNuget
     Target.create "PaketUpdate" paketUpdate
@@ -907,6 +907,9 @@ let initTargets () =
 
         $"PackProvider.{providerName}"
         ==>! "PackProviders"
+
+        $"PublishProvider.{providerName}"
+        ==>! "PublishProviders"
     )
 
     //-----------------------------------------------------------------------------
@@ -969,6 +972,12 @@ let initTargets () =
     ==> "PublishToNuGet"
     // ==> "GitHubRelease"
     ==>! "Publish"
+
+    "DotnetRestore"
+    =?> ("CheckFormatCode", isCI.Value)
+    ==> "BuildProviders"
+    ==> "PackProviders"
+    ==>! "PublishProviders"
 
     "DotnetRestore"
     ==>! "WatchTests"


### PR DESCRIPTION
This PR adds a build target and GHA workflow that calls `paket update` before creating a new branch and PRing the changes to `paket.lock`.