### PR TITLE
Fix CI permissions for `github-actions[bot]`

### DIFF
--- a/.github/workflows/paket-autoupdate.yml
+++ b/.github/workflows/paket-autoupdate.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   paket-update:
     permissions:
+      contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,11 @@
-name: .NET Publish
+name: .NET Publish (Release)
 
 on:
   push:
     branches:
       - main
-      - dev
+    paths:
+      - src/**
 env:
   CONFIGURATION: Release
 jobs:

--- a/build/build.fs
+++ b/build/build.fs
@@ -739,13 +739,14 @@ let paketUpdate _ =
             (Git.Information.getBranchName rootDirectory)
             newBranch
 
+        Git.Staging.stageFile rootDirectory "paket.lock" |> ignore
         Git.Commit.exec rootDirectory prTitle
 
         Git.Branches.pushBranch rootDirectory gitHubRepoUrl newBranch
 
         let pr = Octokit.NewPullRequest(prTitle, newBranch, releaseBranch,Body = prTitle)
         GitHub.createClientWithToken (Option.get githubToken)
-        |> GitHub.createPullRequest gitRepoName gitOwner pr
+        |> GitHub.createPullRequest gitRepoName "github-actions[bot]" pr
         |> Async.RunSynchronously
         |> Async.RunSynchronously
         |> ignore


### PR DESCRIPTION
## Purpose

This PR adds `content: write` permissions to the `paket-autoupdate.yml` workflow to allow GHA to create commits, and PRs changes using the `github-actions[bot]` user instead of the repository owner. It also filters the `Publish` workflow for the extensions to only run when there are changes to `src/`.