### PR TITLE
fix(build.fs): +paket update pr targets the correct repo

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -746,7 +746,7 @@ let paketUpdate _ =
 
         let pr = Octokit.NewPullRequest(prTitle, newBranch, releaseBranch,Body = prTitle)
         GitHub.createClientWithToken (Option.get githubToken)
-        |> GitHub.createPullRequest gitRepoName "github-actions[bot]" pr
+        |> GitHub.createPullRequest gitOwner gitRepoName pr
         |> Async.RunSynchronously
         |> Async.RunSynchronously
         |> ignore


### PR DESCRIPTION
## Changes

This PR fixes the arguments to `createPullRequest` to target the correct repository.