### PR TITLE
Fix path filters for "Publish Providers"; distinguish action from "Publish Extensions"

### DIFF
--- a/.github/workflows/publish-providers.yml
+++ b/.github/workflows/publish-providers.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - src/
+
 env:
   CONFIGURATION: Release
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: .NET Publish (Release)
+name: .NET Publish Extensions
 
 on:
   push:


### PR DESCRIPTION
## Summary

This PR corrects the `publish-providers.yml` action's path filtering and updates the name of `publish.yml` to be descriptive of what it's publishing.