### PR TITLE
increase fetch-depth to 2 for paket.lock.previous

### DIFF
--- a/.github/workflows/publish-providers.yml
+++ b/.github/workflows/publish-providers.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - name: Setup necessary dotnet SDKs
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Purpose

This PR increases the fetch depth for `publish-providers.yml`, allowing `git show HEAD^1:./paket.lock` to function correctly.