### PR TITLE
Use nuget push for providers

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -716,19 +716,22 @@ let sourceLinkTest _ =
 
 let publishProvider packageName =
     fun (_: TargetParameter) ->
-        let packageFile =
+        let nupkg =
             !!(distDir
                </> $"{packageName}.*.nupkg")
             |> Seq.exactlyOne
 
-        Paket.push (fun pushParams -> {
-            pushParams with
-                ApiKey =
-                    match nugetToken with
-                    | Some s -> s
-                    | _ -> pushParams.ApiKey // assume paket-config was set properly
-
-        })
+        DotNet.nugetPush (fun c -> {
+            c with
+                PushParams = {
+                    c.PushParams with
+                        ApiKey =
+                            match nugetToken with
+                            | Some s -> nugetToken
+                            | _ -> c.PushParams.ApiKey // assume paket-config was set properly
+                        Source = Some publishUrl
+                }
+        }) nupkg
 
 let publishToNuget _ =
     allPublishChecks ()


### PR DESCRIPTION
## Purpose

This PR replaces the use of `paket push` with `nuget push`, which provides finer-grained control over publishing single packages as a target.