### PR TITLE
Fix NuGet package version check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,10 +1,7 @@
 name: .NET Build and Test
 
 on:
-  pull_request:
-    branches:
-      - main
-      - dev
+  pull_request: {}
 env:
   CONFIGURATION: Debug
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,8 @@ env:
   CONFIGURATION: Debug
 jobs:
   build:
+    permissions:
+      packages: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/build/build.fs
+++ b/build/build.fs
@@ -145,16 +145,7 @@ let nugetToken = Environment.environVarOrNone "GITHUB_TOKEN" // "NUGET_TOKEN"
 let packageSource =
     global.Paket.PackageSources.NuGetV3 {
         Url = publishUrl
-        Authentication =
-            match githubToken with
-            | Some token ->
-
-                Paket.NetUtils.AuthProvider.ofUserPassword {
-                    Username = gitOwner
-                    Password = token
-                    Type = Paket.NetUtils.AuthType.Basic
-                }
-            | None -> Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
+        Authentication = Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
     }
 
 let githubSHA = Environment.environVarOrNone "GITHUB_SHA"

--- a/build/paket.references
+++ b/build/paket.references
@@ -1,16 +1,15 @@
 group Build
-Argu
-Octokit
-FSharp.Core
-Fake.IO.FileSystem
-Fake.Core.Target
-Fake.Core.ReleaseNotes
-FAKE.Core.Environment
-Fake.DotNet.Cli
-FAKE.Core.Process
-Fake.DotNet.AssemblyInfoFile
-Fake.Tools.Git
-Fake.DotNet.Paket
-Fake.Api.GitHub
-Fake.BuildServer.GitHubActions
-Paket.Core
+  Argu
+  Fake.Api.GitHub
+  Fake.BuildServer.GitHubActions
+  Fake.Core.Target
+  Fake.Core.ReleaseNotes
+  Fake.Core.Environment
+  Fake.Core.Process
+  Fake.DotNet.AssemblyInfoFile
+  Fake.DotNet.Cli
+  Fake.DotNet.Paket
+  Fake.IO.FileSystem
+  Fake.Tools.Git
+  Octokit
+  Paket.Core


### PR DESCRIPTION
## Purpose

This PR uses Paket instead of FAKE to query for the latest versions of packages. FAKE assumes the presence of certain NuGet APIs that Github packages don't support. By using Paket, we avoid hitting unavailable APIs when retrieving the latest version of packages to determine whether it should publish a new version.