### PR TITLE
Fix NuGet package version check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,10 +1,7 @@
 name: .NET Build and Test
 
 on:
-  pull_request:
-    branches:
-      - main
-      - dev
+  pull_request: {}
 env:
   CONFIGURATION: Debug
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Add Paket credentials
         run: |
           dotnet tool restore
-          dotnet paket config add-credentials https://nuget.pkg.github.com --username $GITHUB_ACTOR --password GITHUB_TOKEN --authtype basic --verify
+          paket config add-credentials https://nuget.pkg.github.com --username $GITHUB_ACTOR --password $GITHUB_TOKEN --authtype basic --verify
+          cat ~/.config/Paket/paket.config
       - name: Build providers
         env:
           FAKE_DETAILED_ERRORS: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Add Paket credentials
         run: |
           dotnet tool restore
-          paket config add-credentials https://nuget.pkg.github.com --username $GITHUB_ACTOR --password GITHUB_TOKEN --authtype basic --verify
+          dotnet paket config add-credentials https://nuget.pkg.github.com --username $GITHUB_ACTOR --password GITHUB_TOKEN --authtype basic --verify
       - name: Build providers
         env:
           FAKE_DETAILED_ERRORS: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Add Paket credentials
         run: |
           dotnet tool restore
-          paket config add-credentials https://nuget.pkg.github.com --username $GITHUB_ACTOR --password $GITHUB_TOKEN --authtype basic --verify
+          dotnet paket config add-credentials https://nuget.pkg.github.com --username $GITHUB_ACTOR --password $GITHUB_TOKEN --authtype basic --verify
           cat ~/.config/Paket/paket.config
       - name: Build providers
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,10 @@ jobs:
           global-json-file: global.json
           dotnet-version: |
             8.x
+      - name: Add Paket credentials
+        run: |
+          dotnet tool restore
+          paket config add-credentials https://nuget.pkg.github.com --username $GITHUB_ACTOR --password GITHUB_TOKEN --authtype basic --verify
       - name: Build providers
         env:
           FAKE_DETAILED_ERRORS: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,8 @@ env:
   CONFIGURATION: Debug
 jobs:
   build:
+    permissions:
+      packages: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,13 +17,9 @@ jobs:
           global-json-file: global.json
           dotnet-version: |
             8.x
-      - name: Add Paket credentials
-        run: |
-          dotnet tool restore
-          dotnet paket config add-credentials https://nuget.pkg.github.com --username $GITHUB_ACTOR --password $GITHUB_TOKEN --authtype basic --verify
-          cat ~/.config/Paket/paket.config
       - name: Build providers
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FAKE_DETAILED_ERRORS: true
           ENABLE_COVERAGE: false
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,8 +6,6 @@ env:
   CONFIGURATION: Debug
 jobs:
   build:
-    permissions:
-      packages: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-providers.yml
+++ b/.github/workflows/publish-providers.yml
@@ -9,7 +9,6 @@ env:
   CONFIGURATION: Release
 jobs:
   build:
-    # Sets permissions of the GITHUB_TOKEN to allow release creating
     permissions:
       packages: write
     environment:

--- a/build/build.fs
+++ b/build/build.fs
@@ -145,16 +145,7 @@ let nugetToken = Environment.environVarOrNone "GITHUB_TOKEN" // "NUGET_TOKEN"
 let packageSource =
     global.Paket.PackageSources.NuGetV3 {
         Url = publishUrl
-        Authentication =
-            match githubToken with
-            | Some token ->
-
-                Paket.NetUtils.AuthProvider.ofUserPassword {
-                    Username = gitOwner
-                    Password = token
-                    Type = Paket.NetUtils.AuthType.Basic
-                }
-            | None -> Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
+        Authentication = Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
     }
 
 let githubSHA = Environment.environVarOrNone "GITHUB_SHA"

--- a/build/build.fs
+++ b/build/build.fs
@@ -145,15 +145,7 @@ let nugetToken = Environment.environVarOrNone "GITHUB_TOKEN" // "NUGET_TOKEN"
 let packageSource =
     global.Paket.PackageSources.NuGetV3 {
         Url = publishUrl
-        Authentication =
-            match githubToken with
-            | Some token ->
-                Paket.NetUtils.AuthProvider.ofUserPassword {
-                    Username = Fake.BuildServer.GitHubActions.Environment.Actor
-                    Password = token
-                    Type = Paket.NetUtils.AuthType.Basic
-                }
-            | None -> Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
+        Authentication = Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
     }
 
 let githubSHA = Environment.environVarOrNone "GITHUB_SHA"

--- a/build/build.fs
+++ b/build/build.fs
@@ -145,7 +145,15 @@ let nugetToken = Environment.environVarOrNone "GITHUB_TOKEN" // "NUGET_TOKEN"
 let packageSource =
     global.Paket.PackageSources.NuGetV3 {
         Url = publishUrl
-        Authentication = Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
+        Authentication =
+            match githubToken with
+            | Some token ->
+                Paket.NetUtils.AuthProvider.ofUserPassword {
+                    Username = Fake.BuildServer.GitHubActions.Environment.Actor
+                    Password = token
+                    Type = Paket.NetUtils.AuthType.Basic
+                }
+            | None -> Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
     }
 
 let githubSHA = Environment.environVarOrNone "GITHUB_SHA"

--- a/build/build.fs
+++ b/build/build.fs
@@ -148,11 +148,7 @@ let packageSource =
         Authentication =
             match githubToken with
             | Some token ->
-                Paket.NetUtils.AuthProvider.ofUserPassword {
-                    Username = Fake.BuildServer.GitHubActions.Environment.Actor
-                    Password = token
-                    Type = Paket.NetUtils.AuthType.Basic
-                }
+                Paket.NetUtils.AuthProvider.ofAuth (Paket.NetUtils.Token token)
             | None -> Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
     }
 

--- a/build/build.fs
+++ b/build/build.fs
@@ -145,11 +145,7 @@ let nugetToken = Environment.environVarOrNone "GITHUB_TOKEN" // "NUGET_TOKEN"
 let packageSource =
     global.Paket.PackageSources.NuGetV3 {
         Url = publishUrl
-        Authentication =
-            match githubToken with
-            | Some token ->
-                Paket.NetUtils.AuthProvider.ofAuth (Paket.NetUtils.Token token)
-            | None -> Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
+        Authentication = Paket.AuthService.GetGlobalAuthenticationProvider publishUrl
     }
 
 let githubSHA = Environment.environVarOrNone "GITHUB_SHA"

--- a/build/paket.references
+++ b/build/paket.references
@@ -1,16 +1,15 @@
 group Build
-Argu
-Octokit
-FSharp.Core
-Fake.IO.FileSystem
-Fake.Core.Target
-Fake.Core.ReleaseNotes
-FAKE.Core.Environment
-Fake.DotNet.Cli
-FAKE.Core.Process
-Fake.DotNet.AssemblyInfoFile
-Fake.Tools.Git
-Fake.DotNet.Paket
-Fake.Api.GitHub
-Fake.BuildServer.GitHubActions
-Paket.Core
+  Argu
+  Fake.Api.GitHub
+  Fake.BuildServer.GitHubActions
+  Fake.Core.Target
+  Fake.Core.ReleaseNotes
+  Fake.Core.Environment
+  Fake.Core.Process
+  Fake.DotNet.AssemblyInfoFile
+  Fake.DotNet.Cli
+  Fake.DotNet.Paket
+  Fake.IO.FileSystem
+  Fake.Tools.Git
+  Octokit
+  Paket.Core


### PR DESCRIPTION
## Purpose

This PR uses Paket instead of FAKE to query for the latest versions of packages. FAKE assumes the presence of certain NuGet APIs that Github packages don't support. By using Paket, we avoid hitting unavailable APIs when retrieving the latest version of packages to determine whether it should publish a new version.