### PR TITLE
Paket Auto-update: Give github-bot `packages: read` permission

### DIFF
--- a/.github/workflows/paket-autoupdate.yml
+++ b/.github/workflows/paket-autoupdate.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   paket-update:
     permissions:
+      packages: read
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

This PR adds `packages: read` permissions to the `paket-autoupdate.yml`. Because the actor for this workflow is Github bot, it seems that it requires explicit permission.