### PR TITLE
Improve reliability of Paket autoupdate when all providers are up to date; enable auto merge

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup necessary dotnet SDKs
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/paket-autoupdate.yml
+++ b/.github/workflows/paket-autoupdate.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup necessary dotnet SDKs
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/publish-providers.yml
+++ b/.github/workflows/publish-providers.yml
@@ -15,9 +15,7 @@ jobs:
       name: nuget
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
+      - uses: actions/checkout@v4
       - name: Setup necessary dotnet SDKs
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       name: nuget
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup necessary dotnet SDKs
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Purpose

This PR adds a check to the `PaketUpdate` build target that allows it to exit gracefully if there are no changes. It also calls `gh pr merge --auto` on PRs generated by `github-bot`.