### PR TITLE
Paket auto-update: Add `--squash` to `gr pr merge --auto`

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -730,7 +730,7 @@ let paketUpdate _ =
             let prMergeResult = Process.shellExec { 
                 Program = "gh"
                 WorkingDir = rootDirectory
-                CommandLine = $"pr merge {pr.Number} --auto"
+                CommandLine = $"pr merge {pr.Number} --squash --auto"
                 Args = []
             }
             if prMergeResult <> 0 then failwith $"gh pr merge failed with exit code {prMergeResult}"


### PR DESCRIPTION
## Purpose

This PR adds `--squash` to `gh pr merge --auto` in the `PaketUpdate` build target, which is required when running in non-interactive mode.