### PR TITLE
Paket auto-update checks git status for `paket.lock` changes

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -696,7 +696,11 @@ let paketUpdate _ =
         |> Paket.LockFile.LoadFrom
 
     if Paket.UpdateProcess.Update(dependencies, Paket.UpdaterOptions.Default) then
-        if not (Git.Information.isCleanWorkingCopy rootDirectory) then
+        let modified = 
+            Git.FileStatus.getChangedFilesInWorkingCopy
+                rootDirectory
+                (Git.Information.getCurrentSHA1 rootDirectory)
+        if Seq.contains (Git.FileStatus.Modified, "paket.lock") modified then
             let newLockfile =
                 (rootDirectory
                 </> "paket.lock")


### PR DESCRIPTION
## Purpose

Previously, in order to bail successfully from a `PaketUpdate` run, we tried to check if the working directory was clean (no changes to `paket.lock`) but this is error-prone in CI. Instead, we check the list of changed files for `paket.lock` explicitly.