### PR TITLE
Fix AWS provider for >6.49; improvements to ResourceOptions

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -695,10 +695,13 @@ let paketUpdate _ =
          </> "paket.lock")
         |> Paket.LockFile.LoadFrom
 
-    if  Paket.UpdateProcess.UpdateGroup(
-        dependencies,
-        Paket.Domain.GroupName "Providers",
-        Paket.UpdaterOptions.Default) then
+    if
+        Paket.UpdateProcess.UpdateGroup(
+            dependencies,
+            Paket.Domain.GroupName "Providers",
+            Paket.UpdaterOptions.Default
+        )
+    then
 
         let modified =
             Git.FileStatus.getChangedFilesInWorkingCopy

--- a/src/Pulumi.FSharp.Core/Config.fs
+++ b/src/Pulumi.FSharp.Core/Config.fs
@@ -2,15 +2,29 @@ module Pulumi.FSharp.Config
 
 open Pulumi
 
-let private pulumiConfig = Lazy<Config>(fun _ -> Config())
+let private pulumiConfig = lazy Config()
 
 type Config() =
     member _.Item
         with get (name) = pulumiConfig.Value.Require(name)
 
+    member _.get<'T> (key: string) =
+        pulumiConfig.Value.RequireObject<'T>(key)
+
+    member _.tryGet<'T when 'T: null> (key: string) =
+        pulumiConfig.Value.GetObject<'T>(key)
+        |> Option.ofObj
+
 type SecretConfig() =
     member _.Item
         with get (name) = pulumiConfig.Value.RequireSecret(name)
+
+    member _.get<'T> (key: string) =
+        pulumiConfig.Value.RequireSecretObject<'T>(key)
+
+    member _.tryGet<'T> (key: string) =
+        pulumiConfig.Value.GetSecretObject<'T>(key)
+        |> Option.ofObj
 
 // Type provider for YAML config variables
 let config = Config()

--- a/src/Pulumi.FSharp.Myriad/AstHelpers.fs
+++ b/src/Pulumi.FSharp.Myriad/AstHelpers.fs
@@ -154,6 +154,20 @@ type Expr =
             )
         )
 
+    static member appTuple(func: SynExpr, args) =
+        Expr.app (
+            func,
+            Expr.paren (
+                Expr.tuple (
+                    args
+                    |> List.map Expr.ident
+                )
+            )
+        )
+
+    static member appTuple(func: string, args: SynExpr list) =
+        Expr.app (func, Expr.paren (Expr.tuple args))
+
     static member match'(expr, clauses) = SynExpr.CreateMatch(expr, clauses)
 
     /// value

--- a/src/Pulumi.FSharp.Myriad/Builder.fs
+++ b/src/Pulumi.FSharp.Myriad/Builder.fs
@@ -1,5 +1,6 @@
 module AstBuilder
 
+open Myriad.Core.AstExtensions
 open AstOperations
 open AstInstance
 open AstHelpers
@@ -202,17 +203,140 @@ let createBuilderClass isType isComponent name pTypes =
             if not isType then
                 croOperation
                     "DependsOn"
+                    ResourceOptions
                     "Ensure this resource gets created after its dependency"
                     "dependency"
                     (inputListOfInput "dependency")
+                    false
                     true
 
-            if not isType then
                 croOperation
                     "DependsOn"
+                    ResourceOptions
                     "Ensure this resource gets created after its dependency"
                     "dependency"
                     (inputListOfResources "dependency")
+                    true
                     false
+
+                croOperation
+                    "Id"
+                    ResourceOptions
+                    "An optional existing ID to load, rather than create."
+                    "resourceId"
+                    (Expr.ident "resourceId")
+                    false
+                    true
+
+                croOperation
+                    "IgnoreChanges"
+                    ResourceOptions
+                    "If set to True, the providers Delete method will not be called for this resource."
+                    "paths"
+                    (Expr.ident "paths")
+                    true
+                    true
+
+                croOperation
+                    "ReplaceOnChanges"
+                    ResourceOptions
+                    """Changes to any of these property paths will force a replacement.  If this list includes `"*"`, changes to any properties will force a replacement.  Initialization errors from previous deployments will require replacement instead of update only if `"*"` is passed."""
+                    "paths"
+                    (Expr.ident "paths")
+                    true
+                    true
+
+                croOperation
+                    "ResourceTransformations"
+                    ResourceOptions
+                    "Optional list of transformations to apply to this resource during construction.The transformations are applied in order, and are applied prior to transformation applied to parents walking from the resource up to the stack."
+                    "transformations"
+                    (Expr.ident "transformations")
+                    true
+                    true
+
+                croOperation
+                    "RetainOnDelete"
+                    ResourceOptions
+                    "If set to True, the providers Delete method will not be called for this resource."
+                    "retain"
+                    (Expr.ident "retain")
+                    false
+                    true
+
+                croOperation
+                    "Urn"
+                    ResourceOptions
+                    "The URN of a previously-registered resource of this type to read from the engine."
+                    "urn"
+                    (Expr.ident "urn")
+                    false
+                    true
+
+                croOperation
+                    "Protect"
+                    ResourceOptions
+                    "When set to true, protect ensures this resource cannot be deleted."
+                    "isProtected"
+                    (Expr.ident "isProtected")
+                    false
+                    true
+
+                croOperation
+                    "Parent"
+                    ResourceOptions
+                    "An optional parent resource to which this resource belongs."
+                    "parent"
+                    (Expr.ident "parent")
+                    false
+                    true
+
+                // CustomResourceOptions-specific types
+                if not isComponent then
+                    croOperation
+                        "AdditionalSecretOutputs"
+                        CustomResourceOptions
+                        "The names of outputs for this resource that should be treated as secrets. This augments the list that the resource provider and pulumi engine already determine based on inputs to your resource. It can be used to mark certain outputs as a secrets on a per resource basis."
+                        "outputs"
+                        (Expr.ident "outputs")
+                        true
+                        true
+
+                    croOperation
+                        "DeleteBeforeReplace"
+                        CustomResourceOptions
+                        "When set to `true`, indicates that this resource should be deleted before its replacement is created when replacement is necessary."
+                        "deletedBeforeReplace"
+                        (Expr.ident "deletedBeforeReplace")
+                        false
+                        true
+
+                    croOperation
+                        "ImportId"
+                        CustomResourceOptions
+                        "When provided with a resource ID, import indicates that this resource's provider should import its state from the cloud resource with the given ID. The inputs to the resource's constructor must align with the resource's current state. Once a resource has been imported, the import property must be removed from the resource's options."
+                        "resourceId"
+                        (Expr.ident "resourceId")
+                        false
+                        true
+
+                    croOperation
+                        "Provider"
+                        ResourceOptions
+                        "An optional provider to use for this resource's CRUD operations. If no provider is supplied, the default provider for the resource's package will be used. The default provider is pulled from the parent's provider bag (see also ComponentResourceOptions.providers)."
+                        "resourceProvider"
+                        (Expr.ident "resourceProvider")
+                        false
+                        true
+
+                else
+                    croOperation
+                        "Providers"
+                        ComponentResourceOptions
+                        "An optional set of providers to use for child resources."
+                        "resourceProviders"
+                        (Expr.ident "resourceProviders")
+                        true
+                        true
         ]
     )

--- a/src/Pulumi.FSharp.Myriad/CHANGELOG.md
+++ b/src/Pulumi.FSharp.Myriad/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2024-10-01
+
+Support for `ResourceOptions`-derived types has been improved, allowing more flexible customization 
+
+### Added
+- Various custom operations that represent `ResourceOptions` in the Pulumi .NET SDK.
+
+### Fixed
+- Fixed an issue where specific resource types could not be used as inputs to other Pulumi resources (such as in the AWS providers >6.49)
+- Some providers such as AWS and Docker, which use inconsistent casing for resource names, now handle names case-insensitivitely.
+
 ## [3.1.7] - 2024-06-24
 
 Pulumi providers that use `ComponentResource` as a base class are now interpreted correctly by the Myriad compiler extension.


### PR DESCRIPTION
## Proposed Changes

This PR bundles two changes:
- A fix for the AWS provider, which both began using inconsistent casing for resource names and references and using Pulumi resources as inputs to other resources.
- Improvements to `ResourceOptions`, allowing consumers to specify most of the resource options currently defined by the Pulumi SDK.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
